### PR TITLE
added screenshots and a description under examples section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,10 @@ title: 'Bug: '
 
 *What did you expect to happen?*
 
-## Example
+## Example/Screenshots
+
+*Please provide relevent screenshots as it not only allows you to help explain the problem more clearly but also allows the reviewer to visually see the bug or its effect*
+
 
 *Please provide the smallest code sample possible to reproduce the bug.*
 *We recommend using CodePen, JSbin, or CodeSandbox to provide a live example of the issue.*


### PR DESCRIPTION
## Added screenshots and a description under examples section

Made changes as asked in "Bug template: Incentivize to share screenshots #46" at https://github.com/yvesgurcan/web-midi-player/issues/46 by modifying section name and also adding a description.

-

## Checklist

- [ ] Changes are documented.

## Issue(s) adressed

#46  

- Closes #
